### PR TITLE
[fr] fix errors in fr branch in compilation of the site

### DIFF
--- a/fr/02-git-basics/01-chapter2.markdown
+++ b/fr/02-git-basics/01-chapter2.markdown
@@ -348,7 +348,7 @@ Souvenez-vous que tout ce qui encore non indexé — tous les fichiers qui ont 
 Ils resteront en tant que fichiers modifiés sur votre disque.
 
 Dans notre cas, la dernière fois que vous avez lancé `git status`, vous avez vérifié que tout était indexé, et vous êtes donc prêt à valider vos modifications.
-La manière la plus simple de valider est de taper `git commit :
+La manière la plus simple de valider est de taper `git commit` :
 
 	$ git commit
 

--- a/fr/04-git-server/01-chapter4.markdown
+++ b/fr/04-git-server/01-chapter4.markdown
@@ -692,7 +692,7 @@ En d'autres termes, il devient possible d'indiquer que certaines personnes (ou g
 
 L'installation de Gitolite est très simple, même sans lire la documentation extensive qui l'accompagne.
 Vous n'avez besoin que d'un compte sur un serveur de type Unix ; plusieurs distributions Linux et Solaris 10 sont compatibles.
-Vous n'avez pas besoin d'accès root si git, perl et un<serveur compatible openssh sont déjà installés.
+Vous n'avez pas besoin d'accès root si git, perl et un serveur compatible openssh sont déjà installés.
 Dans les exemples qui suivent, un compte `gitolite` sur un serveur `gitserver` sera utilisé.
 
 Par rapport au concept de logiciel serveur, Gitolite est plutôt inhabituel : l'accès se fait via ssh et donc tout utilisateur du système est potentiellement un « hôte Gitolite ».

--- a/fr/06-git-tools/01-chapter6.markdown
+++ b/fr/06-git-tools/01-chapter6.markdown
@@ -144,7 +144,7 @@ Pour consulter le reflog au format `git log`, exécutez: `git log -g` :
 
 Veuillez noter que le reflog ne stocke que des informations locales, c'est un historique de ce que vous avez fait dans votre dépôt.
 Les références ne sont pas copiées dans un autre dépôt; et juste après le clone d'un dépôt, votre reflog sera vide, puisque qu'aucune activité ne s'y sera produite.
-Exécuter `git show` HEAD@{2.months.ago}` ne fonctionnera que si vous avez dupliqué ce projet depuis au moins 2 mois — si vous l'avez dupliqué il y a 5 minutes, vous n'obtiendrez rien.
+Exécuter `git show HEAD@{2.months.ago}` ne fonctionnera que si vous avez dupliqué ce projet depuis au moins 2 mois — si vous l'avez dupliqué il y a 5 minutes, vous n'obtiendrez rien.
 
 ### Références passées ###
 
@@ -315,7 +315,7 @@ Si vous exécutez `git add` avec l'option `-i` ou `--interactive`, Git rentre en
 Vous vous apercevrez que cette commande propose une vue bien différente de votre zone d'attente; en gros, c'est la même information que vous auriez obtenue avec `git status` mais en plus succint et plus instructif.
 Cela liste les modifications que vous avez mises en attente à gauche, et celles en cours à droite.
 
-En dessous vient la section des commandes (*** Commands ***).
+En dessous vient la section des commandes (*Commands*).
 Vous pourrez y faire bon nombre de choses, notamment mettre en attente des fichiers, les enlever de la zone d'attente, mettre en attente des parties de fichiers, ajouter des fichiers non indexés, et vérifier les différences de ce que vous avez mis en attente.
 
 ### Mettre en attente des fichiers ###

--- a/fr/07-customizing-git/01-chapter7.markdown
+++ b/fr/07-customizing-git/01-chapter7.markdown
@@ -146,7 +146,7 @@ Si vous avez une version antérieure, vous devrez spécifier les règles de colo
 Dans les plupart des cas, si vous tenez vraiment à coloriser vos sorties redirigées, vous pourrez passer le drapeau `--color` à la commande Git pour la forcer à utiliser les codes de couleur.
 Le réglage `color.ui = true` est donc le plus utilisé.
 
-#### color.* ####
+#### `color.*` ####
 
 Si vous souhaitez être plus spécifique concernant les commandes colorisées ou si vous avez une ancienne version, Git propose des paramètres de colorisation par action.
 Chacun peut être fixé à `true`, `false` ou `always`.

--- a/fr/09-git-internals/01-chapter9.markdown
+++ b/fr/09-git-internals/01-chapter9.markdown
@@ -703,7 +703,7 @@ En ligne de commande, vous pouvez tirer plusieurs branches de cette façon :
 	 ! [rejected]        master     -> origin/mymaster  (non fast forward)
 	 * [new branch]      topic      -> origin/topic
 
-Dans ce cas, la récupération /* pull */ de la branche `master` a été refusée car ce n'était pas une avance rapide.
+Dans ce cas, la récupération *pull* de la branche `master` a été refusée car ce n'était pas une avance rapide.
 On peut surcharger ce comportement en précisant un `+` devant la spécification de la référence.
 
 On peut aussi indiquer plusieurs spécifications de référence pour la récupération, dans le fichier de configuration.


### PR DESCRIPTION
Some markup (in fact markdown!) errors have been spotted in the compilation logs of progit.github.com and fixed.
